### PR TITLE
DTA21-BE 会員情報登録API 実装

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const router = require('express').Router()
 const sampleRouter = require('./sample')
+const signupRouter = require('./signup')
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 router.use('/sample', sampleRouter)
+router.use('/signup', signupRouter)
 
 module.exports = router

--- a/backend/routes/signup/index.js
+++ b/backend/routes/signup/index.js
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const router = require('express').Router()
+const fs = require('fs')
+
+router.post('/', (req, res) => {
+  let body = undefined
+  if (!validateUserInfo(req.body)) {
+    res.status(400)
+    body = { message: 'Bad Request' }
+    res.send()
+    return
+  }
+
+  try {
+    const newUserId = createUserId()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const newUser = { [newUserId]: req.body }
+    updateDataBase('./backend/userInfo.json', newUser)
+
+    res.status(200)
+    body = { message: 'ok', userId: newUserId }
+  } catch (err) {
+    console.log(err)
+    res.status(500)
+    body = { message: 'Internal server error' }
+  }
+  setTimeout(() => res.send(body))
+})
+
+module.exports = router
+
+const validateUserInfo = (userInfo) => {
+  const neededKeys = ['name', 'password', 'nickname', 'mail', 'mode', 'photo', 'selfIntro', 'favorites', 'hobbies']
+
+  // for内部でreturnする場合は、forEachはarray.mapは不適切なのでfor ofを使用
+  for (const key of neededKeys) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (userInfo[key] === undefined || userInfo[key] === '') {
+      return false
+    }
+  }
+  return true
+}
+
+const createUserId = () => {
+  // UUID format
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (a) {
+    let r = (new Date().getTime() + Math.random() * 16) % 16 | 0,
+      v = a == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+
+  // TODO: 重複チェックを実装する
+}
+
+const updateDataBase = (filePath, newValue) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const currentValues = JSON.parse(fs.readFileSync(filePath))
+  const newValues = { ...currentValues, ...newValue }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  fs.writeFileSync(filePath, JSON.stringify(newValues, null, 2), 'utf8')
+}


### PR DESCRIPTION
## チケット

<!-- チケット番号を記載してください -->

## 説明

<!-- 変更内容を記載してください -->
signup APIのbackend実装。

### コミット

<!-- 主要な commit とその変更内容を記載 -->
研修のため割愛。

## 動作確認
frontendからリクエストを送信し、正常に登録完了時、入力項目が不足していた場合のそれぞれで、想定通り動作することを確認。

正常に完了した場合　--> 200 + BEで生成した新規のユーザーIDを返す。
![image](https://user-images.githubusercontent.com/111116632/191032123-453817d0-6259-4cdc-9a91-2b260862f0dd.png)
![image](https://user-images.githubusercontent.com/111116632/191032129-9c725ab2-919e-4103-91cf-2e9673dcce36.png)

リクエストが不正の場合(項目が足りない or 未入力がある) --> 400エラー。ただし、趣味と好みは未入力でもエラーにならないようにしています。
![image](https://user-images.githubusercontent.com/111116632/191032585-3a3b7ff2-c205-4f26-a28a-730c471a3eb6.png)




<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->

## 問題点

<!-- 問題点があれば記載 -->
ユーザーIDの重複チェックは今後実施します。(UUID形式なので、よっぽど重複はないと思いますが)
異常系の実装が足りてないところがありそうですが、ひとまず正常系優先のため、この状態でPR出します。

