### PR TITLE
Improve page transition

### DIFF
--- a/src/components/errorPage/ErrorPage.tsx
+++ b/src/components/errorPage/ErrorPage.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import classes from '@/components/errorPage/style.css'
+import { Header } from '@/components/header/Header'
+import { Footer } from '@/components/footer/Footer'
+
+import { sampleState } from '@/atoms/userInfoAtom'
+import { useRecoilState } from 'recoil'
+
+type ResJson = {
+  name: string
+}
+
+export const ErrorPage = () => {
+  const [sample, setSample] = useRecoilState(sampleState)
+  return (
+    <>
+      <Header />
+      {sample}
+      <div className={classes.container}>
+        <h2>404 Page not found.</h2>
+        <ul>
+          <li>
+            <Link to="/signin">Sign in</Link>
+          </li>
+          <li>
+            <Link to="/signup">Sign up</Link>
+          </li>
+          <li>
+            <Link to="/home">Member list</Link>
+          </li>
+
+          <li>
+            <Link to="/matched">Matched members</Link>
+          </li>
+        </ul>
+      </div>
+      <div className={classes.footerContainer}>
+        <Footer />
+      </div>
+    </>
+  )
+}

--- a/src/components/signup/Signup.tsx
+++ b/src/components/signup/Signup.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FC } from 'react'
 import classes from '@/components/signup/style.css'
+import { useNavigate } from 'react-router-dom'
 import { Header } from '@/components/header/Header'
 import { Footer } from '@/components/footer/Footer'
 import { Form } from '@/components/form/Form'
@@ -33,6 +34,8 @@ export const Signup: FC<PropsType> = (props) => {
   const [image, setImage] = useState<File>(undefined)
   const [selfIntro, setSelfIntro] = useState<string>(props.mode === 'create' ? undefined : userInfo[Object.keys(userInfo)[0]].selfIntro)
 
+  const navigate = useNavigate()
+
   const handleSignup = async () => {
     const b64img = await encodeImgToBase64()
 
@@ -65,7 +68,7 @@ export const Signup: FC<PropsType> = (props) => {
 
         const storedInfo: UserInfoType = { [userId]: newUserInfo }
         setUserInfo(storedInfo)
-        window.location.href = '/'
+        navigate('/')
       } else {
         console.error('err')
       }


### PR DESCRIPTION
## チケット

<!-- チケット番号を記載してください -->

なし

## 説明

<!-- 変更内容を記載してください -->
ページ遷移時にrecoilの状態が保持されない問題の対応。
vannila JSの`window.location.href`ではなく、
Reactの機能である、`<Link>`もしくは`useNavigate()`を使うのが正解でした。

### コミット

<!-- 主要な commit とその変更内容を記載 -->
割愛。

## 動作確認

<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->
ページ遷移後もデータが保持されていることを確認。
(元々も、recoil-persistを使ってるので保持されていましたが、これでrecoil-persistを使わなくても保持できます。
ただし、F5更新時はrecoil-persistがないと保持できないので、導入したままです)

## 問題点

<!-- 問題点があれば記載 -->
特になし。

