### PR TITLE
Add image blur to chat page (merge先はチャット実装ブランチです)

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -118,7 +118,6 @@ export const Chat = () => {
       </div>
       <div className={classes.footerContainer}>
         <Footer />
-        {familiarity}
       </div>
     </div>
   )

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -27,10 +27,12 @@ export const Chat = () => {
   const [sendMessage, setSendMessage] = useState<string>(undefined)
   const [chatHistory, setChatHistory] = useState<ChatHistoryType>([])
   const [partnerPhoto, setPartnerPhoto] = useState<string>(undefined)
+  const [familiarity, setFamiliarity] = useState<number>(undefined)
 
   const userInfo = useRecoilValue(userInfoState)
   const loginUserId: string = Object.keys(userInfo)[0]
   const loginUserPhoto: string = userInfo[Object.keys(userInfo)[0]].photo
+  const isSecretMode = userInfo[Object.keys(userInfo)[0]].isSecretMode
   // const partnerId = location.state.partnerId // TODO: mainと結合してから別PRで反映
   const partnerId = 'b830fcc6-b691-462a-beb0-20a73eeed2d9'
 
@@ -60,8 +62,10 @@ export const Chat = () => {
     const resJson: ResJson = await response.json()
     if (resJson.chatHistory) {
       setChatHistory(resJson.chatHistory)
+      setFamiliarity(resJson.familiarity)
     } else {
       setChatHistory([])
+      setFamiliarity(0)
     }
   }
 
@@ -76,6 +80,7 @@ export const Chat = () => {
         setSendMessage('')
         const resJson: ResJson = await response.json()
         setChatHistory(resJson.chatHistory)
+        setFamiliarity(resJson.familiarity)
       } else {
         console.error('err')
       }
@@ -89,7 +94,11 @@ export const Chat = () => {
       <Header menuExist={true} />
       {Object.keys(chatHistory).map((i) => (
         <div key={i} className={chatHistory[i].personId1 === loginUserId ? classes.sendChatContainer : classes.receiveChatContainer}>
-          <img src={chatHistory[i].personId1 === loginUserId ? loginUserPhoto : partnerPhoto} className={classes.photo}></img>
+          <img
+            src={chatHistory[i].personId1 === loginUserId ? loginUserPhoto : partnerPhoto}
+            className={classes.photo}
+            style={isSecretMode ? { filter: `blur(${familiarity > 5 ? 0 : 10 - familiarity * 2}px)` } : null}
+          ></img>
           <p className={classes.message}>{chatHistory[i].content}</p>
         </div>
       ))}
@@ -109,6 +118,7 @@ export const Chat = () => {
       </div>
       <div className={classes.footerContainer}>
         <Footer />
+        {familiarity}
       </div>
     </div>
   )


### PR DESCRIPTION
## チケット

<!-- チケット番号を記載してください -->

https://dojouserappgroup4.atlassian.net/browse/DTA-133

## 説明

<!-- 変更内容を記載してください -->
チャット画面の写真にblurを追加しました。

### コミット

<!-- 主要な commit とその変更内容を記載 -->
割愛。

## 動作確認

<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->
familiarityに応じてblurが少なくなっていき、familiarityが5で完全にblurがなくなることを確認。

※画像最下部の数字は、debug表示したfamiliarityなので、実際には表示されません。

familiarity：2の場合
![image](https://user-images.githubusercontent.com/111116632/192945827-087132b1-4be0-4ddf-91bd-890ba3b902f3.png)

familiarity：5の場合
![image](https://user-images.githubusercontent.com/111116632/192946035-723c795c-c432-43de-8a4c-5dc136335a54.png)



## 問題点

<!-- 問題点があれば記載 -->
チャット画面のスタイルは、速水さんが別ブランチで鋭意実装中です。
